### PR TITLE
a block of suggested changes connected to FeaturesValidation

### DIFF
--- a/Code/GraphMol/MolStandardize/Validate.h
+++ b/Code/GraphMol/MolStandardize/Validate.h
@@ -211,19 +211,27 @@ class RDKIT_MOLSTANDARDIZE_EXPORT DisallowedRadicalValidation
 /// The list of undesired features currently includes query atoms
 /// and bonds, dummy atoms, atom aliases, and (optionally)
 /// enhanced stereochemistry.
-class RDKIT_MOLSTANDARDIZE_EXPORT FeaturesValidation
-    : public ValidationMethod {
+class RDKIT_MOLSTANDARDIZE_EXPORT FeaturesValidation : public ValidationMethod {
  public:
-  FeaturesValidation(bool allowEnhancedStereo=false, bool allowAromaticBondType=false)
-    : allowEnhancedStereo(allowEnhancedStereo), allowAromaticBondType(allowAromaticBondType) {};
+  FeaturesValidation(bool allowEnhancedStereo = false,
+                     bool allowAromaticBondType = false,
+                     bool allowQueries = false, bool allowDummies = false,
+                     bool allowAtomAliases = false)
+      : allowEnhancedStereo(allowEnhancedStereo),
+        allowAromaticBondType(allowAromaticBondType),
+        allowQueries(allowQueries),
+        allowDummies(allowDummies),
+        allowAtomAliases(allowAtomAliases){};
   std::vector<ValidationErrorInfo> validate(
       const ROMol &mol, bool reportAllFailures) const override;
   std::shared_ptr<ValidationMethod> copy() const override {
     return std::make_shared<FeaturesValidation>(*this);
   }
- private:
   bool allowEnhancedStereo;
   bool allowAromaticBondType;
+  bool allowQueries;
+  bool allowDummies;
+  bool allowAtomAliases;
 };
 
 //! The Is2DValidation class reports an error if the input

--- a/Code/GraphMol/MolStandardize/Wrap/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Validate.cpp
@@ -17,25 +17,23 @@ using namespace RDKit;
 
 namespace {
 
-struct ValidationMethodWrap : MolStandardize::ValidationMethod, python::wrapper<MolStandardize::ValidationMethod>
-{
-    std::vector<MolStandardize::ValidationErrorInfo> validate(
-      const ROMol &mol, bool reportAllFailures) const override
-    {
-        return this->get_override("validate")(mol, reportAllFailures);
-    }
+struct ValidationMethodWrap
+    : MolStandardize::ValidationMethod,
+      python::wrapper<MolStandardize::ValidationMethod> {
+  std::vector<MolStandardize::ValidationErrorInfo> validate(
+      const ROMol &mol, bool reportAllFailures) const override {
+    return this->get_override("validate")(mol, reportAllFailures);
+  }
 
-    std::shared_ptr<MolStandardize::ValidationMethod> copy() const override
-    {
-        return this->get_override("copy")();
-    }
+  std::shared_ptr<MolStandardize::ValidationMethod> copy() const override {
+    return this->get_override("copy")();
+  }
 };
 
 // Wrap ValidationMethod::validate and convert the returned
 // vector into a python list of strings
-python::list pythonValidateMethod(
-    const MolStandardize::ValidationMethod & self, const ROMol &mol,
-    bool reportAllFailures) {
+python::list pythonValidateMethod(const MolStandardize::ValidationMethod &self,
+                                  const ROMol &mol, bool reportAllFailures) {
   python::list res;
   std::vector<MolStandardize::ValidationErrorInfo> errout =
       self.validate(mol, reportAllFailures);
@@ -104,101 +102,92 @@ struct validate_wrapper {
     std::string docString = "";
 
     python::class_<ValidationMethodWrap, boost::noncopyable>("ValidationMethod")
-      .def("validate", pythonValidateMethod,
-            (python::arg("self"), python::arg("mol"),
-            python::arg("reportAllFailures") = false),
-            "")
-      ;
+        .def("validate", pythonValidateMethod,
+             (python::arg("self"), python::arg("mol"),
+              python::arg("reportAllFailures") = false),
+             "");
 
-    python::class_<
-      MolStandardize::RDKitValidation,
-      python::bases<MolStandardize::ValidationMethod>,
-      boost::noncopyable>("RDKitValidation")
-      ;
+    python::class_<MolStandardize::RDKitValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("RDKitValidation");
 
-    python::class_<
-      MolStandardize::NoAtomValidation,
-      python::bases<MolStandardize::ValidationMethod>,
-      boost::noncopyable>("NoAtomValidation")
-      ;
+    python::class_<MolStandardize::NoAtomValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("NoAtomValidation");
 
-    python::class_<
-      MolStandardize::FragmentValidation,
-      python::bases<MolStandardize::ValidationMethod>,
-      boost::noncopyable>("FragmentValidation")
-      ;
+    python::class_<MolStandardize::FragmentValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("FragmentValidation");
 
-    python::class_<
-      MolStandardize::NeutralValidation,
-      python::bases<MolStandardize::ValidationMethod>,
-      boost::noncopyable>("NeutralValidation")
-      ;
+    python::class_<MolStandardize::NeutralValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("NeutralValidation");
 
-    python::class_<
-      MolStandardize::IsotopeValidation,
-      python::bases<MolStandardize::ValidationMethod>,
-      boost::noncopyable>("IsotopeValidation")
-        .def(python::init<bool>())
-      ;
+    python::class_<MolStandardize::IsotopeValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("IsotopeValidation")
+        .def(python::init<bool>());
 
-    python::class_<
-      MolStandardize::MolVSValidation,
-      python::bases<MolStandardize::ValidationMethod>,
-      boost::noncopyable>("MolVSValidation")
-        .def("__init__", python::make_constructor(&getMolVSValidation))
-      ;
+    python::class_<MolStandardize::MolVSValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("MolVSValidation")
+        .def("__init__", python::make_constructor(&getMolVSValidation));
 
-    python::class_<
-      MolStandardize::AllowedAtomsValidation,
-      python::bases<MolStandardize::ValidationMethod>,
-      boost::noncopyable>("AllowedAtomsValidation", python::no_init)
-        .def("__init__", python::make_constructor(&getAllowedAtomsValidation))
-      ;
+    python::class_<MolStandardize::AllowedAtomsValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("AllowedAtomsValidation",
+                                       python::no_init)
+        .def("__init__", python::make_constructor(&getAllowedAtomsValidation));
 
-    python::class_<
-      MolStandardize::DisallowedAtomsValidation,
-      python::bases<MolStandardize::ValidationMethod>,
-      boost::noncopyable>("DisallowedAtomsValidation", python::no_init)
-        .def("__init__", python::make_constructor(&getDisallowedAtomsValidation))
-      ;
+    python::class_<MolStandardize::DisallowedAtomsValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("DisallowedAtomsValidation",
+                                       python::no_init)
+        .def("__init__",
+             python::make_constructor(&getDisallowedAtomsValidation));
 
-    python::class_<
-      MolStandardize::FeaturesValidation,
-      python::bases<MolStandardize::ValidationMethod>,
-      boost::noncopyable>("FeaturesValidation")
-        .def(python::init<bool>())
-        .def(python::init<bool, bool>())
-      ;
+    python::class_<MolStandardize::FeaturesValidation,
+                   python::bases<MolStandardize::ValidationMethod>>(
+        "FeaturesValidation")
+        .def(python::init<bool, bool, bool, bool, bool>(
+            (python::arg("allowEnhancedStereo") = false,
+             python::arg("allowAromaticBondType") = false,
+             python::arg("allowQueries") = false,
+             python::arg("allowDummmies") = false,
+             python::arg("allowAtomAliases") = false)))
+        .def_readwrite("allowEnhancedStereo",
+                       &MolStandardize::FeaturesValidation::allowEnhancedStereo)
+        .def_readwrite(
+            "allowAromaticBondType",
+            &MolStandardize::FeaturesValidation::allowAromaticBondType)
+        .def_readwrite("allowQueries",
+                       &MolStandardize::FeaturesValidation::allowQueries)
+        .def_readwrite("allowDummies",
+                       &MolStandardize::FeaturesValidation::allowDummies)
+        .def_readwrite("allowAtomAliases",
+                       &MolStandardize::FeaturesValidation::allowAtomAliases);
 
-    python::class_<
-      MolStandardize::DisallowedRadicalValidation,
-      python::bases<MolStandardize::ValidationMethod>,
-      boost::noncopyable>("DisallowedRadicalValidation")
-      ;
+    python::class_<MolStandardize::DisallowedRadicalValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("DisallowedRadicalValidation");
 
-    python::class_<
-      MolStandardize::Is2DValidation,
-      python::bases<MolStandardize::ValidationMethod>,
-      boost::noncopyable>("Is2DValidation")
-        .def(python::init<double>())
-      ;
+    python::class_<MolStandardize::Is2DValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("Is2DValidation")
+        .def(python::init<double>());
 
-    python::class_<
-      MolStandardize::Layout2DValidation,
-      python::bases<MolStandardize::ValidationMethod>,
-      boost::noncopyable>("Layout2DValidation")
+    python::class_<MolStandardize::Layout2DValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("Layout2DValidation")
         .def(python::init<double>())
         .def(python::init<double, double>())
         .def(python::init<double, double, bool>())
         .def(python::init<double, double, bool, double>())
-        .def(python::init<double, double, bool, bool, double>())
-      ;
+        .def(python::init<double, double, bool, bool, double>());
 
-    python::class_<
-      MolStandardize::StereoValidation,
-      python::bases<MolStandardize::ValidationMethod>,
-      boost::noncopyable>("StereoValidation")
-      ;
+    python::class_<MolStandardize::StereoValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("StereoValidation");
 
     python::def("ValidateSmiles", standardizeSmilesHelper, (python::arg("mol")),
                 docString.c_str());

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -1184,6 +1184,10 @@ M  END
     errinfo = validator.validate(mol)
     self.assertEqual(len(errinfo), 1)
     self.assertEqual(errinfo[0], "ERROR: [FeaturesValidation] Query atom 0 is not allowed")
+    validator.allowDummies = True
+    validator.allowQueries = True
+    errinfo = validator.validate(mol)
+    self.assertEqual(len(errinfo), 0)
 
     mol = Chem.MolFromMolBlock('''
   Mrv2311 01162411552D          
@@ -1213,14 +1217,19 @@ M  END
     validator = rdMolStandardize.FeaturesValidation()
     errinfo = validator.validate(mol, True)
     self.assertEqual(len(errinfo), 1)
-    self.assertEqual(errinfo[0], "ERROR: [FeaturesValidation] Enhanced stereochemistry features are not allowed")
+    self.assertEqual(
+      errinfo[0], "ERROR: [FeaturesValidation] Enhanced stereochemistry features are not allowed")
 
     # allow enhanced stereo
     validator = rdMolStandardize.FeaturesValidation(True)
     errinfo = validator.validate(mol, True)
     self.assertEqual(len(errinfo), 0)
+    validator.allowEnhancedStereo = True
+    errinfo = validator.validate(mol)
+    self.assertEqual(len(errinfo), 0)
 
-    mol = Chem.MolFromMolBlock('''
+    mol = Chem.MolFromMolBlock(
+      '''
   Mrv2311 02272411562D          
 
   0  0  0     0  0            999 V3000
@@ -1252,7 +1261,11 @@ M  END
     validator = rdMolStandardize.FeaturesValidation()
     errinfo = validator.validate(mol, True)
     self.assertEqual(len(errinfo), 6)
-    self.assertEqual(errinfo[0], "ERROR: [FeaturesValidation] Bond 0 of aromatic type is not allowed")
+    self.assertEqual(errinfo[0],
+                     "ERROR: [FeaturesValidation] Bond 0 of aromatic type is not allowed")
+    validator.allowAromaticBondType = True
+    errinfo = validator.validate(mol)
+    self.assertEqual(len(errinfo), 0)
 
     # allow aromatic bonds
     validator = rdMolStandardize.FeaturesValidation(False, True)

--- a/Code/GraphMol/MolStandardize/testValidate.cpp
+++ b/Code/GraphMol/MolStandardize/testValidate.cpp
@@ -360,7 +360,48 @@ M  END
     cerr << msg << endl;
   }
   errmsg = errout[0];
-  TEST_ASSERT(errmsg == "ERROR: [FeaturesValidation] Query atom 0 is not allowed");
+  TEST_ASSERT(errmsg ==
+              "ERROR: [FeaturesValidation] Query atom 0 is not allowed");
+  {
+    FeaturesValidation featuresCopy(features);
+    featuresCopy.allowQueries = true;
+    errout = featuresCopy.validate(*mol, true);
+    TEST_ASSERT(errout.empty());
+  }
+
+  mblock = R"(
+                    2D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 2 1 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.8753 4.9367 0 0
+M  V30 2 C -0.4583 4.1667 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 2 1
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)";
+
+  mol.reset(MolBlockToMol(mblock, false, false));
+  mol->getAtomWithIdx(0)->setAtomicNum(0);
+  errout = features.validate(*mol, true);
+  TEST_ASSERT(errout.size() == 1);
+  for (auto msg : errout) {
+    cerr << msg << endl;
+  }
+  errmsg = errout[0];
+  TEST_ASSERT(errmsg ==
+              "ERROR: [FeaturesValidation] Dummy atom 0 is not allowed");
+  {
+    FeaturesValidation featuresCopy(features);
+    featuresCopy.allowDummies = true;
+    errout = featuresCopy.validate(*mol, true);
+    TEST_ASSERT(errout.empty());
+  }
 
   mblock = R"(
   Mrv2311 01162411522D          
@@ -382,11 +423,18 @@ M  END
   mol.reset(MolBlockToMol(mblock, false, false));
   errout = features.validate(*mol, true);
   TEST_ASSERT(errout.size() == 1);
-  for (auto msg: errout) {
+  for (auto msg : errout) {
     cerr << msg << endl;
   }
   errmsg = errout[0];
-  TEST_ASSERT(errmsg == "ERROR: [FeaturesValidation] Query bond 0 is not allowed");
+  TEST_ASSERT(errmsg ==
+              "ERROR: [FeaturesValidation] Query bond 0 is not allowed");
+  {
+    FeaturesValidation featuresCopy(features);
+    featuresCopy.allowQueries = true;
+    errout = featuresCopy.validate(*mol, true);
+    TEST_ASSERT(errout.empty());
+  }
 
   mblock = R"(
   Mrv2311 02272411562D          
@@ -416,15 +464,22 @@ M  V30 END CTAB
 M  END
 )";
 
-
   mol.reset(MolBlockToMol(mblock, false, false));
   errout = features.validate(*mol, true);
   TEST_ASSERT(errout.size() == 6);
-  for (auto msg: errout) {
+  for (auto msg : errout) {
     cerr << msg << endl;
   }
   errmsg = errout[0];
-  TEST_ASSERT(errmsg == "ERROR: [FeaturesValidation] Bond 0 of aromatic type is not allowed");
+  TEST_ASSERT(
+      errmsg ==
+      "ERROR: [FeaturesValidation] Bond 0 of aromatic type is not allowed");
+  {
+    FeaturesValidation featuresCopy(features);
+    featuresCopy.allowAromaticBondType = true;
+    errout = featuresCopy.validate(*mol, true);
+    TEST_ASSERT(errout.empty());
+  }
 
   mblock = R"(
   MJ231601                      
@@ -443,11 +498,19 @@ M  END
   mol.reset(MolBlockToMol(mblock, false, false));
   errout = features.validate(*mol, true);
   TEST_ASSERT(errout.size() == 1);
-  for (auto msg: errout) {
+  for (auto msg : errout) {
     cerr << msg << endl;
   }
   errmsg = errout[0];
-  TEST_ASSERT(errmsg == "ERROR: [FeaturesValidation] Atom 2 with alias 'CF3' is not allowed");
+  TEST_ASSERT(
+      errmsg ==
+      "ERROR: [FeaturesValidation] Atom 2 with alias 'CF3' is not allowed");
+  {
+    FeaturesValidation featuresCopy(features);
+    featuresCopy.allowAtomAliases = true;
+    errout = featuresCopy.validate(*mol, true);
+    TEST_ASSERT(errout.empty());
+  }
 
   mblock = R"(
   Mrv2311 01162411552D          
@@ -476,11 +539,19 @@ M  END
   mol.reset(MolBlockToMol(mblock, false, false));
   errout = features.validate(*mol, true);
   TEST_ASSERT(errout.size() == 1);
-  for (auto msg: errout) {
+  for (auto msg : errout) {
     cerr << msg << endl;
   }
   errmsg = errout[0];
-  TEST_ASSERT(errmsg == "ERROR: [FeaturesValidation] Enhanced stereochemistry features are not allowed");
+  TEST_ASSERT(
+      errmsg ==
+      "ERROR: [FeaturesValidation] Enhanced stereochemistry features are not allowed");
+  {
+    FeaturesValidation featuresCopy(features);
+    featuresCopy.allowEnhancedStereo = true;
+    errout = featuresCopy.validate(*mol, true);
+    TEST_ASSERT(errout.empty());
+  }
 
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }


### PR DESCRIPTION
makes all of the `FeatureValidation` components optional.

I tried to not include all of the reformatting changes that clang-format and yapf wanted to make. If this resulted in code that doesn't work let me know and I will commit the whole thing.

general request: please run clang-format and yapf across all the files in your PR